### PR TITLE
Fix add dependecies via SPM error by explicit state the swift version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,15 +1,16 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
     name: "FSPagerView",
     platforms: [
-        .iOS(.v9)
+        .iOS(.v12)
     ],
     products: [
         .library(name: "FSPagerView", targets: ["FSPagerView"]),
     ],
     targets: [
         .target(name: "FSPagerView", path: "Sources", exclude: ["FSPagerViewObjcCompat.h", "FSPagerViewObjcCompat.m"]),
-    ]
+    ],
+    swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
- Update the swift tool version to 5.9
- Add swiftLanguageVersions parameter in Package.swift